### PR TITLE
Use MongoClient for connection and update pymongo requirements to 2.4

### DIFF
--- a/mongodb_beaker/__init__.py
+++ b/mongodb_beaker/__init__.py
@@ -197,7 +197,7 @@ except ImportError:
     import pickle
 
 try:
-    from pymongo.connection import Connection
+    from pymongo import MongoClient as Connection
     import bson
     import bson.errors
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     """,
     requires=['pymongo', 'beaker'],
     install_requires = [
-        'pymongo>=1.9',
+        'pymongo>=2.4',
         'beaker>=1.5'
     ]
 


### PR DESCRIPTION
It may be a good idea to use MongoClient as it re-uses connection.
