### PR TITLE
Fix host_uri when creating MongoDB connection to a ReplicatSet (see issue #5)

### DIFF
--- a/mongodb_beaker/__init__.py
+++ b/mongodb_beaker/__init__.py
@@ -252,7 +252,7 @@ class MongoDBNamespaceManager(NamespaceManager):
             db = conn[database]
 
             if username:
-                log.info("Attempting to authenticate %s/%s " % (username, password))
+                log.debug("Attempting to authenticate %s/%s " % (username, password))
                 if not db.authenticate(username, password):
                     raise InvalidCacheBackendError('Cannot authenticate to '
                                                    ' MongoDB.')

--- a/mongodb_beaker/__init__.py
+++ b/mongodb_beaker/__init__.py
@@ -245,8 +245,7 @@ class MongoDBNamespaceManager(NamespaceManager):
 
         def _create_mongo_conn():
             host_uri = 'mongodb://'
-            for x in host_list:
-                host_uri += '%s:%s' % x
+            host_uri += ','.join(['{0}:{1}'.format(*x) for x in host_list])
             log.info("Host URI: %s" % host_uri)
             conn = Connection(host_uri, slave_okay=options.get('slaveok', False))
 


### PR DESCRIPTION
When rebuilding the MongoDB URL, do not forget to add `,` between the hosts.
